### PR TITLE
Add support for Patroni

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all: rpm
+
+rpm:
+	docker-compose run --rm centos7
+
+clean:
+	rm -rf rpm/
+
+.PHONY: rpm clean

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 This modules adds the file contexts needed by the RPM of PostgreSQL
 provided by the PGDG (e.g. yum.postgresql.org). It requires the
-`postgresql` module of the ref policy.
+`postgresql` module of the ref policy, which is enabled by default.
 
-Currently, it only has been tested with RHEL/Centos 6, using policy version 24.
+## RedHat Version / Support
+
+Version up to 1.2.0 support RHEL/Centos 6 (policy version 24)
+
+As of 1.3.0, it supports RHEL/Centos 7 (policy version 31).
+
 It does not force you to enable sepgsql.
-
-*Note:* when running the postmaster on a TCP port different than 5432, you
-need to allow it to bind to the port by adding a `semanage port` rule to the
-local policy.
 
 ## Boolean Provided
 
@@ -24,6 +25,34 @@ postgresql_pgdg_can_http --> on
 #
 ```
 
+Read/Write access to watchdog devices is provided by the
+`postgresql_pgdg_use_watchdog` boolean. The purpose of this boolean is
+to allow confining Patroni (a HA framework for PostgreSQL) with the
+`postgresql_t` type. Patroni being in charge of running the
+postmaster.
+
+``` console
+# setsebool postgresql_pgdg_use_watchdog on
+# getsebool postgresql_pgdg_use_watchdog
+postgresql_pgdg_use_watchdog --> on
+#
+```
+
+## Notes
+
+When running the postmaster on a TCP port different than 5432, you
+need to allow it to bind to the port by adding a `semanage port` rule to the
+local policy.
+
+Appling `postgresql_t` to Patroni requires to :
+
+* enable `postgresql_pgdg_can_http`
+* label the DCS tcp port with `http_port_t` (tested with Etcd)
+* use a unregistered port for the API of Patroni and label it with `postgresql_port_t`
+
+
+# License
+
 This is free software distributed under the PostgreSQL license.
 
-Copyright (c) 2014-2019 Dalibo.
+Copyright (c) 2014-2020 Dalibo.

--- a/postgresql-pgdg.fc
+++ b/postgresql-pgdg.fc
@@ -10,7 +10,7 @@
 #
 /usr/pgsql-[0-9]+(\.[0-9]+)?/bin/initdb		--	gen_context(system_u:object_r:postgresql_exec_t,s0)
 /usr/pgsql-[0-9]+(\.[0-9]+)?/bin/postgres	--	gen_context(system_u:object_r:postgresql_exec_t,s0)
-/usr/pgsql-[0-9]+(\.[0-9]+)?/bin/pg_ctl		--	gen_context(system_u:object_r:postgresql_initrc_exec_t,s0)
+/usr/pgsql-[0-9]+(\.[0-9]+)?/bin/pg_ctl		--	gen_context(system_u:object_r:postgresql_exec_t,s0)
 
 /usr/pgsql-[0-9]+(\.[0-9]+)?/share/locale(/.*)?		gen_context(system_u:object_r:locale_t,s0)
 /usr/pgsql-[0-9]+(\.[0-9]+)?/share/man(/.*)?		gen_context(system_u:object_r:man_t,s0)
@@ -20,3 +20,9 @@
 #
 /var/lib/pgsql/[0-9]+(\.[0-9]+)?/pgstartup\.log.*	gen_context(system_u:object_r:postgresql_log_t,s0)
 /var/lib/pgsql/[0-9]+(\.[0-9]+)?/data/(pg_)?log(/.*)?	gen_context(system_u:object_r:postgresql_log_t,s0)
+
+#
+# Patroni
+#
+/opt/patroni/bin/patroni			--	gen_context(system_u:object_r:postgresql_exec_t,s0)
+/bin/patroni                                    --      gen_context(system_u:object_r:postgresql_exec_t,s0)

--- a/postgresql-pgdg.te
+++ b/postgresql-pgdg.te
@@ -1,4 +1,4 @@
-policy_module(postgresql-pgdg, 1.2.0)
+policy_module(postgresql-pgdg, 1.3.0)
 
 require {
         type postgresql_t;
@@ -14,4 +14,16 @@ gen_tunable(postgresql_pgdg_can_http, false)
 tunable_policy(`postgresql_pgdg_can_http',`
     corenet_tcp_connect_http_port(postgresql_t)
     corenet_tcp_sendrecv_http_port(postgresql_t)
+')
+
+## <desc>
+##      <p>
+##      Allow PostgreSQL/Patroni to access Watchdog devices
+##      </p>
+## </desc>
+gen_tunable(postgresql_pgdg_use_watchdog, false)
+
+tunable_policy(`postgresql_pgdg_use_watchdog',`
+    dev_read_watchdog(postgresql_t)
+    dev_write_watchdog(postgresql_t)
 ')

--- a/selinux-policy-pgsql-pgdg.spec
+++ b/selinux-policy-pgsql-pgdg.spec
@@ -4,7 +4,7 @@
 %global relabelpath /usr/pgsql-*/*
 
 Name: selinux-policy-pgsql-pgdg
-Version: 1.2.0
+Version: 1.3.0
 Release: 1
 Summary: SELinux policy module for PostgreSQL from the PGDG
 License: PostgreSQL
@@ -80,6 +80,9 @@ fi
 %doc README.md
 
 %changelog
+* Sat Sep 19 2020 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.3.0-1
+- Support Patroni
+
 * Fri Oct 11 2019 Étienne BERSAC <etienne.bersac@dalibo.com> - 1.2.0-1
 - Add postgresql_pgdg_can_http boolean.
 


### PR DESCRIPTION
Add a boolean to enable rw access to watchdog devices, required for
fencing. Fix the type of pg_ctl, and bump to 1.3.0