### PR TITLE
Add postgresql_pgdg_use_nfs boolean

### DIFF
--- a/postgresql-pgdg.te
+++ b/postgresql-pgdg.te
@@ -1,4 +1,4 @@
-policy_module(postgresql-pgdg, 1.3.1)
+policy_module(postgresql-pgdg, 1.4.0)
 
 require {
         type postgresql_t;
@@ -26,4 +26,17 @@ gen_tunable(postgresql_pgdg_use_watchdog, false)
 tunable_policy(`postgresql_pgdg_use_watchdog',`
     dev_read_watchdog(postgresql_t)
     dev_write_watchdog(postgresql_t)
+')
+
+## <desc>
+##     <p>
+##     Allow PostgreSQL to use NFS filesystems
+##     </p>
+## </desc>
+gen_tunable(postgresql_pgdg_use_nfs, false)
+
+tunable_policy(`postgresql_pgdg_use_nfs',`
+    fs_manage_nfs_dirs(postgresql_t)
+    fs_manage_nfs_files(postgresql_t)
+    fs_manage_nfs_symlinks(postgresql_t)
 ')

--- a/selinux-policy-pgsql-pgdg.spec
+++ b/selinux-policy-pgsql-pgdg.spec
@@ -4,7 +4,7 @@
 %global relabelpath /usr/pgsql-*/*
 
 Name: selinux-policy-pgsql-pgdg
-Version: 1.3.1
+Version: 1.4.0
 Release: 1%{dist}
 Summary: SELinux policy module for PostgreSQL from the PGDG
 License: PostgreSQL
@@ -80,6 +80,9 @@ fi
 %doc README.md
 
 %changelog
+* Fri Oct 30 2020 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.4.0-1
+- Allow to use NFS
+
 * Mon Sep 21 2020 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.3.1-1
 - Fix path of patroni executable
 


### PR DESCRIPTION
This new boolean let postgresql_t context read/write access to NFS
shares. It is off by default. The purpose is to let PostgreSQL archive
WAL files on a mounted NFS share, as part of PITR.